### PR TITLE
Fixing Typographical Errors in Repository Descriptions

### DIFF
--- a/landing/tutorials-and-demos/repositories.mdx
+++ b/landing/tutorials-and-demos/repositories.mdx
@@ -20,7 +20,7 @@ description: "Collection of demos and examples application using Particle Networ
   Demo application showcasing how to use custom JWT authentication with Particle Auth.
   </Card>
         <Card title="upgrade-autkit-demo" href="https://github.com/Particle-Network/upgrade-autkit-demo">
-    Example repository showcasing how to umpgrade from `auth-core-modal` to `Authkit`.
+    Example repository showcasing how to upgrade from `auth-core-modal` to `Authkit`.
   </Card>
 </CardGroup>
 
@@ -64,7 +64,7 @@ description: "Collection of demos and examples application using Particle Networ
 
 <CardGroup cols={3}>
           <Card title="particle-connectkit2.0-quickstart" href="https://github.com/Particle-Network/particle-connectkit2.0-quickstart">
-    Demo application shocasing how to get started with Particle Connect.
+    Demo application showcasing how to get started with Particle Connect.
   </Card>
 
   <Card title="duckchain-aa-connect" href="https://github.com/Particle-Network/duckchain-aa-connect">


### PR DESCRIPTION
**Description:**

I noticed a couple of typographical errors in the repository descriptions that needed correction for clarity and professionalism:

1. The word **"umpgrade"** in the repository **"upgrade-autkit-demo"** was corrected to **"upgrade"**.
2. The word **"shocasing"** in the repository **"particle-connectkit2.0-quickstart"** was corrected to **"showcasing"**.

These changes are important because even small typographical errors can create confusion or affect the perceived quality of documentation. Correcting these ensures that the descriptions are clear and maintain a professional standard.